### PR TITLE
added "block" prop toggle for the inline display type

### DIFF
--- a/src/component/Popper.vue
+++ b/src/component/Popper.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="inline-block"
+    :class="{'inline-block': !block}"
     :style="interactiveStyle"
     @mouseleave="hover && closePopper()"
     ref="popperContainerNode"
@@ -176,6 +176,13 @@
       type: String,
       default: null,
     },
+    /**
+     * Toggle the wrapper block or inline-block display type
+     */
+    block: {
+      type: Boolean,
+      default: false
+    }
   });
 
   const popperContainerNode = ref(null);


### PR DESCRIPTION
I needed to warp a full width element so to do that I need to be able to toggle the inline-block class on the wrapper,
this is done with the prop `block` here. 

might be related to https://github.com/valgeirb/vue3-popper/issues/6#issuecomment-885637124