### PR TITLE
fix: vue-devtool display Anonymous Component

### DIFF
--- a/src/component/Popper.vue
+++ b/src/component/Popper.vue
@@ -30,7 +30,11 @@
     </Transition>
   </div>
 </template>
-
+<script>
+export default {
+  name: "Popper",
+}
+</script>
 <script setup>
   import { debounce } from "debounce";
   import {


### PR DESCRIPTION
when use vue3-popper in <script setup> component, devtool display  "Anonymous Component"
![image](https://user-images.githubusercontent.com/20860159/176385083-87a427a4-f575-417f-a1f5-1578421e1b9c.png)
