### PR TITLE
Cursor pointer on hover

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,4 @@ The `content` slot gives you access to useful variables and functions.
 | `--popper-theme-border-radius`          | 6px                                 |
 | `--popper-theme-padding`                | 16px                                |
 | `--popper-theme-box-shadow`             | 0 6px 30px -6px rgba(0, 0, 0, 0.25) |
+| `--popper-theme-cursor-hover`           | cursor                              |

--- a/dev/serve.vue
+++ b/dev/serve.vue
@@ -41,5 +41,6 @@
     --popper-theme-border-radius: 6px;
     --popper-theme-padding: 32px;
     --popper-theme-box-shadow: 0 6px 30px -6px rgba(0, 0, 0, 0.25);
+    --popper-theme-cursor-hover: pointer;
   }
 </style>

--- a/docs/components/PopperDemo.vue
+++ b/docs/components/PopperDemo.vue
@@ -48,5 +48,6 @@
     --popper-theme-border-radius: 6px;
     --popper-theme-padding: 32px;
     --popper-theme-box-shadow: 0 6px 30px -6px rgba(0, 0, 0, 0.25);
+    --popper-theme-cursor-hover: pointer;
   }
 </style>

--- a/docs/guide/api.md
+++ b/docs/guide/api.md
@@ -57,3 +57,4 @@ The `content` slot gives you access to useful variables and functions.
 | `--popper-theme-border-radius`          | 6px                                 |
 | `--popper-theme-padding`                | 16px                                |
 | `--popper-theme-box-shadow`             | 0 6px 30px -6px rgba(0, 0, 0, 0.25) |
+| `--popper-theme-cursor-hover`           | pointer                              |

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -107,6 +107,7 @@ If your content is more complex, you can use the `#content` slot:
 | `--popper-theme-border-radius`          | 6px                                 |
 | `--popper-theme-padding`                | 16px                                |
 | `--popper-theme-box-shadow`             | 0 6px 30px -6px rgba(0, 0, 0, 0.25) |
+| `--popper-theme-cursor-hover`           | pointer                              |
 
 You can overwrite them any way you like, for example in a Vue component:
 
@@ -127,6 +128,7 @@ You can overwrite them any way you like, for example in a Vue component:
     --popper-theme-border-radius: 6px;
     --popper-theme-padding: 32px;
     --popper-theme-box-shadow: 0 6px 30px -6px rgba(0, 0, 0, 0.25);
+    --popper-theme-cursor-hover: pointer;
   }
 </style>
 ```
@@ -143,6 +145,7 @@ You could also create a `theme.css` file:
   --popper-theme-border-radius: 6px;
   --popper-theme-padding: 32px;
   --popper-theme-box-shadow: 0 6px 30px -6px rgba(0, 0, 0, 0.25);
+  --popper-theme-cursor-hover: pointer;
 }
 ```
 

--- a/src/component/Popper.vue
+++ b/src/component/Popper.vue
@@ -320,6 +320,7 @@
   .popper:hover,
   .popper:hover > #arrow::before {
     background: var(--popper-theme-background-color-hover);
+    cursor: var(--popper-theme-cursor-hover);
   }
 
   .inline-block {


### PR DESCRIPTION
When the mouse is over the Popper, it could be great to be able to change the `cursor`, setting it to `pointer`.