### PR TITLE
expose open, close and toggle methods

### DIFF
--- a/src/component/Popper.vue
+++ b/src/component/Popper.vue
@@ -42,6 +42,7 @@
     watch,
     watchEffect,
     onMounted,
+    defineExpose,
   } from "vue";
   import { usePopper, useContent, useClickAway } from "@/composables";
   import Arrow from "./Arrow.vue";
@@ -298,6 +299,12 @@
       useClickAway(popperContainerNode, closePopper);
     }
   });
+
+  defineExpose({
+    openPopper,
+    closePopper,
+    togglePopper,
+  })
 </script>
 
 <style scoped>


### PR DESCRIPTION
Exposes the following methods: `openPopper`, `closePopper` and `togglePopper`.

This would be useful to open and close the popper using another components, like a button somewhere else.