### PR TITLE
exposed popper update method to allow parents to call it

### DIFF
--- a/src/component/Popper.vue
+++ b/src/component/Popper.vue
@@ -42,6 +42,7 @@
     watch,
     watchEffect,
     onMounted,
+    defineExpose
   } from "vue";
   import { usePopper, useContent, useClickAway } from "@/composables";
   import Arrow from "./Arrow.vue";
@@ -205,7 +206,7 @@
     show,
   } = toRefs(props);
 
-  const { isOpen, open, close } = usePopper({
+  const { isOpen, popperInstance, open, close } = usePopper({
     arrowPadding,
     emit,
     locked,
@@ -215,6 +216,10 @@
     popperNode,
     triggerNode,
   });
+
+  defineExpose({
+    update: popperInstance.value.update
+  })
 
   const { hasContent } = useContent(slots, popperNode, content);
 


### PR DESCRIPTION
Popper content that resizes itself while the popper is open currently can lead to positioning issues as the popper can't update itself.

The example I'm currently working with is a popper menu that allows searching for users, expanding the height and width of the popper.

Exposing the update method of the underlying popper instance would allow parent components to force the position to update. This would hopefully increase the possible use cases for the library