### PR TITLE
fix: isOpen is not cleared when popper is closed

### DIFF
--- a/src/component/Popper.vue
+++ b/src/component/Popper.vue
@@ -256,6 +256,10 @@
     isOpen.value ? closePopper() : openPopper();
   };
 
+  const debouncedIsOpenClear = debounce(() => {
+    modifiedIsOpen.value = false;
+  }, 200);
+
   /**
    * If Popper is open, we automatically close it if it becomes
    * disabled or without content.
@@ -275,9 +279,7 @@
     if (isOpen) {
       modifiedIsOpen.value = true;
     } else {
-      debounce(() => {
-        modifiedIsOpen.value = false;
-      }, 200);
+      debouncedIsOpenClear();
     }
   });
 


### PR DESCRIPTION
Debounce is incorrectly used, which result in that isOpen is never set back to false.